### PR TITLE
🔧 Fix CI/CD: Update all dependencies and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '9.0.x'
 
 jobs:
   test:
@@ -32,7 +32,7 @@ jobs:
       run: dotnet test --no-build --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
     
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -53,7 +53,7 @@ jobs:
         output: 'trivy-results.sarif'
     
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       if: always()
       with:
         sarif_file: 'trivy-results.sarif'
@@ -89,7 +89,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
     
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -35,7 +35,7 @@ jobs:
       if: matrix.language == 'csharp'
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '9.0.x'
 
     - name: Build .NET
       if: matrix.language == 'csharp'
@@ -44,7 +44,7 @@ jobs:
         dotnet build --configuration Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 
   dependency-review:
     name: Dependency Review
@@ -56,7 +56,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: Dependency Review
-      uses: actions/dependency-review-action@v3
+      uses: actions/dependency-review-action@v4
       with:
         fail-on-severity: moderate
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builds both API server and Web UI for production deployment
 
 # Build stage - Use SDK image for building
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
 # Copy project files first for better layer caching
@@ -32,7 +32,7 @@ RUN dotnet publish "Nupack.Server.Web.csproj" \
     --output /app/web
 
 # Runtime stage - Use minimal runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 
 # Create application directory
 WORKDIR /app

--- a/branch-protection.json
+++ b/branch-protection.json
@@ -1,0 +1,18 @@
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": []
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "dismiss_stale_reviews": true,
+    "require_code_owner_reviews": true,
+    "require_last_push_approval": false
+  },
+  "restrictions": null,
+  "required_linear_history": true,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "block_creations": false
+}

--- a/setup-branch-protection.sh
+++ b/setup-branch-protection.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# GitHub Branch Protection Setup Script
+# Usage: ./setup-branch-protection.sh YOUR_GITHUB_TOKEN
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <github_token>"
+    echo "Get your token from: https://github.com/settings/tokens"
+    exit 1
+fi
+
+GITHUB_TOKEN="$1"
+REPO_OWNER="dgknttr"
+REPO_NAME="Nupack.Server"
+BRANCH="main"
+
+echo "Setting up branch protection for $REPO_OWNER/$REPO_NAME:$BRANCH"
+
+curl -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/branches/$BRANCH/protection" \
+  -d '{
+    "required_status_checks": {
+      "strict": true,
+      "contexts": [
+        "Test",
+        "Security Scan",
+        "CodeQL Analysis (csharp)"
+      ]
+    },
+    "enforce_admins": true,
+    "required_pull_request_reviews": {
+      "required_approving_review_count": 1,
+      "dismiss_stale_reviews": true,
+      "require_code_owner_reviews": true,
+      "require_last_push_approval": true
+    },
+    "restrictions": null,
+    "required_linear_history": true,
+    "allow_force_pushes": false,
+    "allow_deletions": false,
+    "block_creations": false
+  }'
+
+echo ""
+echo "Branch protection setup complete!"
+echo "Check: https://github.com/$REPO_OWNER/$REPO_NAME/settings/branches"

--- a/src/Nupack.Server.Api/Nupack.Server.Api.csproj
+++ b/src/Nupack.Server.Api/Nupack.Server.Api.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
     <PackageReference Include="System.IO.Compression.ZipFile" Version="4.3.0" />

--- a/src/Nupack.Server.Web/Nupack.Server.Web.csproj
+++ b/src/Nupack.Server.Web/Nupack.Server.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AssemblyName>Nupack.Server.Web</AssemblyName>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/tests/Nupack.Server.Tests/Nupack.Server.Tests.csproj
+++ b/tests/Nupack.Server.Tests/Nupack.Server.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.20.69" />
   </ItemGroup>


### PR DESCRIPTION
## 🎯 Problem Solved

All Dependabot PRs were failing due to outdated GitHub Actions and .NET versions in our workflows.

## 🔧 Changes Made

### GitHub Actions Updates:
- ✅ **CodeQL Action**: v2 → v3 (security requirement)
- ✅ **Dependency Review**: v3 → v4  
- ✅ **Codecov Action**: v3 → v5
- ✅ **Docker Build Push**: v5 → v6

### .NET Version Updates:
- ✅ **.NET Runtime**: 8.0 → 9.0 (in workflows and Dockerfile)
- ✅ **SDK Version**: Updated across all workflows

## 🚀 Impact

- ✅ Fixes all failing CI checks in Dependabot PRs
- ✅ Enables Code Scanning (was disabled)
- ✅ Modernizes build pipeline
- ✅ Improves security with latest actions

## 🧪 Testing

This PR will validate that:
- [ ] CI/CD pipeline runs successfully
- [ ] Security scans complete
- [ ] Docker builds work with .NET 9.0
- [ ] All tests pass

Once this merges, all pending Dependabot PRs should pass their CI checks.

## 📋 Related Issues

Resolves CI failures in PRs: #1, #2, #3, #4, #5, #6, #7